### PR TITLE
Fix ASDF data directory path resolution (Fixes #14)

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -44,7 +44,7 @@ asdf_nim_init() {
   # Ensure ASDF_DATA_DIR has a value
   if [ -n "${ASDF_INSTALL_PATH:-}" ]; then
     export ASDF_DATA_DIR
-    ASDF_DATA_DIR="${ASDF_DATA_DIR:-${ASDF_DIR:-$(normpath "${ASDF_INSTALL_PATH:-}/../../..")}}"
+    ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
     export ASDF_NIM_TEMP
     ASDF_NIM_TEMP="${ASDF_DATA_DIR}/tmp/nim/${ASDF_INSTALL_VERSION}"
     export ASDF_NIM_DOWNLOAD_PATH

--- a/shims/nimble
+++ b/shims/nimble
@@ -2,7 +2,7 @@
 
 set -ueo pipefail
 
-ASDF_BIN="${ASDF_DIR:-${ASDF_DATA_DIR:-$HOME/.asdf}}/bin/"
+ASDF_BIN="${ASDF_DIR:-$HOME/.asdf}/bin/"
 ASDF_INSTALL_PATH="$("${ASDF_BIN}/asdf" where nim)"
 
 regenerate() {

--- a/shims/nimble
+++ b/shims/nimble
@@ -2,7 +2,7 @@
 
 set -ueo pipefail
 
-ASDF_BIN="${ASDF_DATA_DIR:-${ASDF_DIR:-$HOME/.asdf}}/bin/"
+ASDF_BIN="${ASDF_DIR:-${ASDF_DATA_DIR:-$HOME/.asdf}}/bin/"
 ASDF_INSTALL_PATH="$("${ASDF_BIN}/asdf" where nim)"
 
 regenerate() {


### PR DESCRIPTION
- Set ASDF_DATA_DIR default just like it is in asdf core.
- Derive ASDF_BIN in nimble shim off of ASDF_DIR first, which is
  the only export guaranteed to be defined, and the sensible default.