### PR TITLE
Do not assume `asdf` executable location in nimble shim

### DIFF
--- a/shims/nimble
+++ b/shims/nimble
@@ -4,7 +4,7 @@ set -ueo pipefail
 
 regenerate() {
   # After a nimble operation, regenerate nim shims to find new package binaries
-  if "$(which asdf)" reshim nim; then
+  if "$(command -v asdf)" reshim nim; then
     echo "  asdf-nim: regenerated shims"
   else
     echo "  asdf-nim: failed to regenerate shims"
@@ -17,7 +17,7 @@ trap 'trap - HUP; SIGNAL=SIGHUP; regenerate; kill -HUP $$' HUP
 trap 'trap - INT; SIGNAL=SIGINT; regenerate; kill -INT $$' INT
 trap 'trap - TERM; SIGNAL=SIGTERM; regenerate; kill -TERM $$' TERM
 
-if "$(dirname $(asdf which nim))/nimble" "$@"; then
+if "$(dirname "$(asdf which nim)")/nimble" "$@"; then
   case "${1-}" in
     install | develop | uninstall)
       regenerate


### PR DESCRIPTION
Hey,

I use `asdf` through a `brew` installation on MacOS.
I installed the latest `nim` and tried to run `nimble init`, which failed with the following error:

```shell
~/.asdf/plugins/nim/shims/nimble: line 6: ~/.asdf/bin//asdf: No such file or directory
~/.asdf/plugins/nim/shims/nimble: line 23: ./nimble: No such file or directory
```

I believe this was caused by a recent version of `asdf` getting rid of the `bin` folder, which was assumed to be containing `asdf`by this shim.

I made a quick draft that works on my local -- just to spark the discussion.
I am not sure what the test strategy is, but I can do my best to help to make sure this change doesn't break any other environment.

Thanks for the project ✌️ 