### PR TITLE
Fix bats integration tests and update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
@@ -131,7 +131,7 @@ jobs:
         run: go install github.com/asdf-vm/asdf/cmd/asdf@master
 
       - name: Checkout plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test plugin
         shell: bash
@@ -160,7 +160,7 @@ jobs:
         run: go install github.com/asdf-vm/asdf/cmd/asdf@master
 
       - name: Checkout plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test plugin
         shell: bash
@@ -196,7 +196,7 @@ jobs:
           key: cache-${{ matrix.arch }}-${{ matrix.nim-version }}
 
       - name: Checkout plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Install & run tests on non-x86
       - uses: uraimo/run-on-arch-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.27.1"
+          # No go.mod in this repo; Go is only used to `go install` asdf.
+          cache: false
 
       - name: Cache test dependencies
         uses: actions/cache@v6
@@ -126,6 +128,8 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.27.1"
+          # No go.mod in this repo; Go is only used to `go install` asdf.
+          cache: false
 
       - name: Install asdf
         run: go install github.com/asdf-vm/asdf/cmd/asdf@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.3"
+          go-version: "1.27.1"
 
       - name: Cache test dependencies
         uses: actions/cache@v4
@@ -125,7 +125,7 @@ jobs:
         if: runner.os != 'macOS'
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.3"
+          go-version: "1.27.1"
 
       - name: Install asdf
         run: go install github.com/asdf-vm/asdf/cmd/asdf@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           go-version: "1.25.3"
 
       - name: Cache test dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .test-cache
           key: test-cache-${{ runner.os }}-asdf-v0.18.0-nim-ref-version-2-2
@@ -107,7 +107,7 @@ jobs:
       # Optimization: re-use cached Nim->C compilation
       - name: Restore cache
         if: matrix.nim-version != 'ref:HEAD' && matrix.nim-version != 'latest'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache
           key: cache-${{ matrix.os }}-${{ matrix.nim-version }}
@@ -148,7 +148,7 @@ jobs:
     steps:
       # Optimization: re-use cached Nim->C compilation
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache
           key: cache-ubuntu-latest-2.2.4
@@ -190,7 +190,7 @@ jobs:
     steps:
       # Optimization: re-use cached Nim->C compilation
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache
           key: cache-${{ matrix.arch }}-${{ matrix.nim-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout plugin
         uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: "24"
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25.3"
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: runner.os != 'macOS'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25.3"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -167,10 +167,22 @@ info() {
   assert [ -f "$nimble_file" ]
   assert [ ! -x "${ASDF_NIM_VERSION_INSTALL_PATH}/nimble/bin/nimjson" ]
 
-  # Assert that nim finds nimble packages
+  # Assert that nim finds nimble packages.
+  # --nimblePath adds each <pkg>-<ver>-<hash> directory itself, not that
+  # package's srcDir. In nimbledeps (local-deps) mode nimble preserves the
+  # package's repository layout, so the modules sit under <pkgdir>/src and
+  # --nimblePath alone cannot resolve them. `nimble setup` emits both <pkgdir>
+  # and <pkgdir>/<srcDir> for this reason; do the same.
+  nimjson_dir="$(dirname "$nimble_file")"
+  nimjson_src="$nimjson_dir"
+  if [ -d "${nimjson_dir}/src" ]; then
+    nimjson_src="${nimjson_dir}/src"
+  fi
+  info "nimble --version: $(nimble --version 2>&1 | head -1)"
+  info "nimjson package layout: $(find "$nimjson_dir" -maxdepth 2 -name 'nimjson.nim' | tr '\n' ' ')"
   echo "import nimjson" >"${ASDF_NIM_TEST_TEMP}/testnimble.nim"
-  info "nim c --nimblePath:./nimbledeps/pkgs2 -r \"${ASDF_NIM_TEST_TEMP}/testnimble.nim\""
-  nim c --nimblePath:./nimbledeps/pkgs2 -r "${ASDF_NIM_TEST_TEMP}/testnimble.nim"
+  info "nim c --path:${nimjson_src} -r \"${ASDF_NIM_TEST_TEMP}/testnimble.nim\""
+  nim c --path:"$nimjson_src" -r "${ASDF_NIM_TEST_TEMP}/testnimble.nim"
 
   rm -rf nimbledeps
 }
@@ -186,7 +198,7 @@ info() {
   assert [ -x "${ASDF_NIM_VERSION_INSTALL_PATH}/nimble/bin/nph" ]
 
   # Assert shim was created
-  assert [ -f "${ASDF_DATA_DIR}/shims/nph" ]
+  assert [ -x "${ASDF_DATA_DIR}/shims/nph" ]
 
   # Assert nph shim is in PATH and is the test's asdf shim (not system install)
   # The test's ASDF_DATA_DIR/shims should be first in PATH
@@ -195,11 +207,22 @@ info() {
   assert [ -n "$nph_path" ]
   assert [ "$nph_path" = "${ASDF_DATA_DIR}/shims/nph" ]
 
-  # Assert nph runs successfully via the test's shim
-  info "nph --version"
-  run nph --version
+  # Assert nph runs via the test's shim.
+  # nph reports `git describe --long --dirty --always --tags` verbatim, so its
+  # --version string tracks upstream's tag layout and is not stable here.
+  # Assert on nph-owned behavior instead.
+  info "nph --help"
+  run nph --help
   assert_success
-  assert_output --regexp "^v[0-9]+"
+  assert_output --partial "nph - Nim formatter"
+
+  # Assert the shimmed binary actually formats, not merely exits 0
+  printf 'echo   "hi"\n' >"${ASDF_NIM_TEST_TEMP}/fmt_test.nim"
+  info "nph \"${ASDF_NIM_TEST_TEMP}/fmt_test.nim\""
+  run nph "${ASDF_NIM_TEST_TEMP}/fmt_test.nim"
+  assert_success
+  run cat "${ASDF_NIM_TEST_TEMP}/fmt_test.nim"
+  assert_output --partial 'echo "hi"'
 }
 
 @test "latest_installs_binary_when_available" {


### PR DESCRIPTION
## Description

Restores a green build and brings in the pending Renovate action/toolchain bumps.

Two bats integration tests were asserting on behavior owned by upstream projects
rather than by this plugin, so both broke without any plugin change:

**`nimble_configuration__with_nimbledeps`** — `--nimblePath` adds each
`<pkg>-<ver>-<hash>` directory itself, not that package's `srcDir`. In nimbledeps
(local-deps) mode nimble preserves the package's repository layout, so nimjson's
modules live at `<pkgdir>/src/` and the import could not resolve. This is why
`nimble setup` writes both `<pkgdir>` and `<pkgdir>/<srcDir>` into `nimble.paths`.
The test now derives the path from the already-discovered `.nimble` file and
prefers `<pkgdir>/src` when it exists, so it passes under both the preserved and
the flattened layout.

**`nimble_package_binary_in_path`** — nph prints
`git describe --long --dirty --always --tags` verbatim, so its `--version` tracks
upstream's tag layout. nph now carries a moving `prerelease` tag on the same commit
as `v0.7.0`, so describe reports `prerelease-0-g2cacf6c-dirty` and the `^v[0-9]+`
regexp fails. Pinning a version would not help, since both tags point at the same
commit. The test now asserts nph-owned behavior instead: the `--help` banner, plus
a format round-trip that proves the shim actually execs nph rather than merely
exiting 0.

Also included:

- Renovate bumps: actions/checkout v7, actions/cache v6, actions/setup-node v7,
  actions/setup-go v7, actions/setup-python v7, Go 1.27.1.
- `cache: false` on both `setup-go` steps. This repo has no `go.mod`; Go is only
  used to `go install` asdf, so setup-go logged
  `Restore cache failed: Dependencies file is not found` on every run.

## Motivation and Context

`build` has been failing since around early March. The last green run was
2026-02-11; every run since has been red, which is why the open Renovate PRs
could not merge. The nph tag change landed 2026-02-16, inside that window.

Neither failure indicated a defect in the plugin — both were tests coupled to
third-party release mechanics.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

No user-facing change. Test and CI configuration only.

## How Has This Been Tested?

Both failures were reproduced locally before fixing, and both fixes verified:

- `nph --version` reproduced byte-identically (`prerelease-0-g2cacf6c-dirty`).
- The old `nim c --nimblePath:./nimbledeps/pkgs2` produced the exact CI error
  (`cannot open file: nimjson`); the new `--path:<pkgdir>/src` compiled and ran.
- The format round-trip assertion was checked against an unformatted file to
  confirm it fails when nph does not run, rather than passing vacuously.

On CI the suite goes from 62/64 to **64/64**. The added diagnostics confirmed the
layout on CI's nimble v0.24.1, a different version than the one used locally.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a green build by fixing two bats tests that broke because they asserted on upstream nimble and nph behavior, and applies the pending Renovate action and toolchain bumps.

**Bug Fixes**
- The nimbledeps test now derives the import path from the discovered `.nimble` file and prefers `<pkgdir>/src` when present, since `--nimblePath` adds package directories themselves rather than their `srcDir`.
- The nph shim test now asserts on the `--help` banner and a format round-trip instead of `--version`, whose output tracks upstream's moving `prerelease` tag and is not stable.
- The shim check was tightened from `-f` to `-x` to match the adjacent assertion.

**Dependencies**
- Bumps `actions/checkout`, `actions/cache`, `actions/setup-node`, `actions/setup-go`, and `actions/setup-python` to their latest major versions, and Go to 1.27.1.
- Sets `cache: false` on both `setup-go` steps; this repo has no `go.mod`, so the module cache restore failed on every run.

<sup>Written for commit 020d380d375292838fa455be605b46678816e618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/asdf-community/asdf-nim/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

