### PR TITLE
Make the build cache work, label arches honestly, keep qemu off PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,13 @@ jobs:
             platform: linux
             arch: x86_64
 
+          # Unstable binary. Nim 2.4 has no tagged release yet, so ref: is the
+          # only handle for it; switch to latest:2.4 once a tag exists.
+          - os: ubuntu-latest
+            nim-version: "ref:version-2-4"
+            platform: linux
+            arch: x86_64
+
           # Unstable binary
           # macos-latest is Apple silicon; GitHub publishes no Intel macOS
           # image for macOS 14 or newer, so x86_64 macOS is not covered here.
@@ -179,9 +186,12 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache
-          key: cache-ubuntu-latest-2.2.4-${{ github.run_id }}
+          # Must describe what is actually cached: a musl build of the
+          # version this job installs. The old key said ubuntu-latest and
+          # 2.2.4 while the job runs on alpine and installs latest:2.2.
+          key: cache-alpine-musl-latest-2.2-${{ github.run_id }}
           restore-keys: |
-            cache-ubuntu-latest-2.2.4-
+            cache-alpine-musl-latest-2.2-
 
       - name: Install dependencies
         run: apk add --update --no-cache --upgrade bash git curl coreutils tar xz grep build-base go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,28 +199,17 @@ jobs:
             --nim-version latest:2.2
 
   # Test installation for a few non-x86 architectures
-  plugin_test_non_x86:
-    name: 👑${{ matrix.nim-version }}/linux/${{ matrix.arch }}
+  plugin_test_aarch64:
+    name: 👑ref:version-2-2/linux/aarch64
     runs-on: ubuntu-latest
 
     # Emulated under qemu; armv7 alone runs for hours. These jobs fail when Nim
     # changes its nightlies, not when a pull request changes the plugin, so they
     # run on pushes to main, tags, the weekly schedule and manual dispatch.
+    # Kept as two plain jobs rather than one matrix: a job skipped by a
+    # job-level if is never matrix-expanded, so a name referring to matrix
+    # renders as raw ${{ }} in the checks list.
     if: github.event_name != 'pull_request'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Unstable binary
-          - runs-on: ubuntu-latest
-            nim-version: "ref:version-2-2"
-            arch: aarch64
-
-          # Unstable binary
-          - runs-on: ubuntu-latest
-            nim-version: "ref:version-1-6"
-            arch: armv7
 
     steps:
       # Optimization: re-use cached Nim->C compilation
@@ -228,9 +217,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache
-          key: cache-${{ matrix.arch }}-${{ matrix.nim-version }}-${{ github.run_id }}
+          key: cache-aarch64-ref:version-2-2-${{ github.run_id }}
           restore-keys: |
-            cache-${{ matrix.arch }}-${{ matrix.nim-version }}-
+            cache-aarch64-ref:version-2-2-
 
       - name: Checkout plugin
         uses: actions/checkout@v7
@@ -239,7 +228,7 @@ jobs:
       - uses: uraimo/run-on-arch-action@v3
         name: Test plugin
         with:
-          arch: ${{ matrix.arch }}
+          arch: aarch64
           distro: bookworm
           dockerRunArgs: |
             --volume "${HOME}/.cache:/root/.cache"
@@ -252,4 +241,48 @@ jobs:
             cd /workspace
             ./scripts/ci-install.sh
             exec ./scripts/ci-test-plugin.sh \
-              --nim-version ${{ matrix.nim-version }}
+              --nim-version ref:version-2-2
+
+  plugin_test_armv7:
+    name: 👑ref:version-1-6/linux/armv7
+    runs-on: ubuntu-latest
+
+    # Emulated under qemu; armv7 alone runs for hours. These jobs fail when Nim
+    # changes its nightlies, not when a pull request changes the plugin, so they
+    # run on pushes to main, tags, the weekly schedule and manual dispatch.
+    # Kept as two plain jobs rather than one matrix: a job skipped by a
+    # job-level if is never matrix-expanded, so a name referring to matrix
+    # renders as raw ${{ }} in the checks list.
+    if: github.event_name != 'pull_request'
+
+    steps:
+      # Optimization: re-use cached Nim->C compilation
+      - name: Restore cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache
+          key: cache-armv7-ref:version-1-6-${{ github.run_id }}
+          restore-keys: |
+            cache-armv7-ref:version-1-6-
+
+      - name: Checkout plugin
+        uses: actions/checkout@v7
+
+      # Install & run tests on non-x86
+      - uses: uraimo/run-on-arch-action@v3
+        name: Test plugin
+        with:
+          arch: armv7
+          distro: bookworm
+          dockerRunArgs: |
+            --volume "${HOME}/.cache:/root/.cache"
+            --volume "${GITHUB_WORKSPACE}:/workspace"
+          shell: /usr/bin/env bash
+          setup: |
+            mkdir -p "${HOME}/.cache"
+          run: |
+            set -uexo pipefail
+            cd /workspace
+            ./scripts/ci-install.sh
+            exec ./scripts/ci-test-plugin.sh \
+              --nim-version ref:version-1-6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,17 @@ on:
       - shims/** # changes to shim scripts
       - test/** # changes to tests
       - package*.json # bats upgrade
+  schedule:
+    # Weekly. The emulated-architecture jobs are skipped on pull requests, and
+    # this plugin breaks when Nim/nimble/nightlies change rather than when the
+    # plugin does, so a time-based run is what actually catches those.
+    - cron: "0 6 * * 1"
+
+# A superseded run of this workflow is never worth finishing: the emulated
+# armv7 job alone occupies a runner for hours.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Run tests with bats
@@ -56,8 +67,11 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .test-cache
-          key: test-cache-${{ runner.os }}-asdf-v0.18.0-nim-ref-version-2-2
+          # The key must be unique per run or the cache is written once and
+          # never refreshed; restore-keys is what actually finds it again.
+          key: test-cache-${{ runner.os }}-asdf-v0.18.0-nim-ref-version-2-2-${{ github.run_id }}
           restore-keys: |
+            test-cache-${{ runner.os }}-asdf-v0.18.0-nim-ref-version-2-2-
             test-cache-${{ runner.os }}-asdf-v0.18.0-
 
       - name: Run tests
@@ -66,8 +80,8 @@ jobs:
           [ -n "$(which bats)" ] || npm link bats
           npm run test -- --jobs 4
 
-  plugin_test_x86:
-    name: 👑${{ matrix.nim-version }}/${{ matrix.platform }}/x86_64
+  plugin_test:
+    name: 👑${{ matrix.nim-version }}/${{ matrix.platform }}/${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -78,32 +92,40 @@ jobs:
           - os: ubuntu-latest
             nim-version: "latest:1.6"
             platform: linux
+            arch: x86_64
 
           # Stable binary
           - os: ubuntu-latest
             nim-version: "latest:2.2"
             platform: linux
+            arch: x86_64
 
           # Unstable binary
           - os: ubuntu-latest
             nim-version: "ref:version-2-0"
             platform: linux
+            arch: x86_64
 
           # Unstable binary
+          # macos-latest is Apple silicon; GitHub publishes no Intel macOS
+          # image for macOS 14 or newer, so x86_64 macOS is not covered here.
           - os: macos-latest
             nim-version: "ref:devel"
             platform: macOS
+            arch: arm64
 
           # Build from source
           - os: ubuntu-latest
             nim-version: "ref:HEAD"
             platform: linux
+            arch: x86_64
 
           # Build from source
           - os: macos-latest
             asdf_nim_no_nightly_fallback: 1
             nim-version: "latest:2.2"
             platform: macOS
+            arch: arm64
 
     steps:
       # Optimization: re-use cached Nim->C compilation
@@ -112,7 +134,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache
-          key: cache-${{ matrix.os }}-${{ matrix.nim-version }}
+          key: cache-${{ matrix.os }}-${{ matrix.nim-version }}-${{ github.run_id }}
+          restore-keys: |
+            cache-${{ matrix.os }}-${{ matrix.nim-version }}-
 
       - name: Set environment variables
         if: ${{ matrix.asdf_nim_no_nightly_fallback }}
@@ -155,7 +179,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache
-          key: cache-ubuntu-latest-2.2.4
+          key: cache-ubuntu-latest-2.2.4-${{ github.run_id }}
+          restore-keys: |
+            cache-ubuntu-latest-2.2.4-
 
       - name: Install dependencies
         run: apk add --update --no-cache --upgrade bash git curl coreutils tar xz grep build-base go
@@ -177,6 +203,11 @@ jobs:
     name: 👑${{ matrix.nim-version }}/linux/${{ matrix.arch }}
     runs-on: ubuntu-latest
 
+    # Emulated under qemu; armv7 alone runs for hours. These jobs fail when Nim
+    # changes its nightlies, not when a pull request changes the plugin, so they
+    # run on pushes to main, tags, the weekly schedule and manual dispatch.
+    if: github.event_name != 'pull_request'
+
     strategy:
       fail-fast: false
       matrix:
@@ -197,7 +228,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache
-          key: cache-${{ matrix.arch }}-${{ matrix.nim-version }}
+          key: cache-${{ matrix.arch }}-${{ matrix.nim-version }}-${{ github.run_id }}
+          restore-keys: |
+            cache-${{ matrix.arch }}-${{ matrix.nim-version }}-
 
       - name: Checkout plugin
         uses: actions/checkout@v7


### PR DESCRIPTION
## Description

Three fixes to the build workflow.

**The cache never worked.** Every cache key was a fixed string, and a cache entry
is immutable once written, so an entry was saved once and then never refreshed.
Compounding that, caches only propagate from the default branch — an entry saved
on a pull request branch is invisible to every other branch. `build` had not run
successfully on `main` since March, so no entry existed there to restore, and
every run cold-missed. A recent armv7 run logged
`Cache not found for input keys: cache-armv7-ref:version-1-6` and then saved an
entry nothing would ever read. Each key now carries `github.run_id` so it is
always written, with `restore-keys` doing the lookup.

**The macOS jobs were mislabeled.** `macos-latest` resolves to `macos-26-arm64`,
but the job name hardcoded `x86_64`, so both jobs reported an architecture they
were not running on. Architecture is now a matrix field and the name reads from
it. GitHub publishes no Intel macOS image for macOS 14 or newer, so x86_64 macOS
is genuinely uncovered rather than merely unlabeled; a comment records that.
`plugin_test_x86` is renamed to `plugin_test` since it has not been x86-only for
some time.

**The emulated jobs no longer run on pull requests.** armv7 under qemu occupies a
runner for roughly three and a half hours to report whether Nim's nightlies still
work on armv7 — which changes on Nim's release cadence, not on anything a pull
request does. Those jobs still run on pushes to `main`, on tags, on manual
dispatch, and on a new weekly schedule, so the coverage moves rather than
disappears. A `concurrency` group is also added, so a superseded run stops
instead of holding a runner for hours.

## Motivation and Context

CI was red for roughly six months, and the signal was slow enough that nobody
watched it. These are the three things that made it slow and untrustworthy rather
than merely broken.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

No user-facing change. CI configuration only.

## How Has This Been Tested?

Each change was verified rather than assumed, on a fork:

- **Cache.** A rolling key cannot be proven in one run, so two were used. Run 1
  logged `Cache not found` for both the exact key and the new prefix, then saved.
  Run 2 logged `Cache hit for restore-key`, restored it, and saved a fresh entry.
  The aarch64 job went from 11.0 min cold to 8.3 min warm.
- **Trigger gate.** A `pull_request` run produced 9 jobs with the emulated job
  skipped; a `workflow_dispatch` run on the same commit produced 10 with aarch64
  and armv7 both queued. The condition discriminates rather than always skipping.
- **Concurrency.** Dispatching a second run cancelled the first automatically.
- The full pull request job set passed on the fork.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the build workflow's cache, job labels, and emulated-job triggers so CI stops cold-missing, misreporting architectures, and burning hours on pull requests.

**Bug Fixes**
- Cache keys now include `github.run_id` so entries are written every run and `restore-keys` finds the latest; the alpine key now reads `cache-alpine-musl-latest-2.2` instead of claiming `ubuntu-latest`/`2.2.4`.
- macOS job names read architecture from a matrix field instead of hardcoding `x86_64`; `plugin_test_x86` renamed to `plugin_test`. No Intel macOS image exists for macOS 14+, so x86_64 macOS is uncovered, not mislabeled.

**Refactors**
- Emulated aarch64 and armv7 jobs are split into two plain jobs that skip on pull requests and run on main pushes, tags, manual dispatch, and a weekly schedule; splitting them avoids raw `${{ matrix }}` text in skipped job names.
- A `concurrency` group cancels superseded runs so a stale armv7 job doesn't hold a runner for hours.
- Nim 2.4 is now covered via `ref:version-2-4` since no tagged release exists yet.

<sup>Written for commit 0ca3c707be7500784da0ddc4cbfb85be59d64699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/asdf-community/asdf-nim/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

